### PR TITLE
Add DateOnly and TimeOnly support

### DIFF
--- a/Community.Data.OData.Linq/Community.OData.Linq.csproj
+++ b/Community.Data.OData.Linq/Community.OData.Linq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>sgn.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -56,6 +56,11 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
       <Version>2.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
+      <Version>6.0.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/Community.Data.OData.Linq/OData/Formatter/EdmLibHelpers.cs
+++ b/Community.Data.OData.Linq/OData/Formatter/EdmLibHelpers.cs
@@ -77,6 +77,12 @@ namespace Community.OData.Linq.OData.Formatter
                 new KeyValuePair<Type, IEdmPrimitiveType>(typeof(char?), GetPrimitiveType(EdmPrimitiveTypeKind.String)),
                 new KeyValuePair<Type, IEdmPrimitiveType>(typeof(DateTime), GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset)),
                 new KeyValuePair<Type, IEdmPrimitiveType>(typeof(DateTime?), GetPrimitiveType(EdmPrimitiveTypeKind.DateTimeOffset)),
+#if NET6_0_OR_GREATER
+                new KeyValuePair<Type, IEdmPrimitiveType>(typeof(DateOnly), GetPrimitiveType(EdmPrimitiveTypeKind.Date)),
+                new KeyValuePair<Type, IEdmPrimitiveType>(typeof(DateOnly?), GetPrimitiveType(EdmPrimitiveTypeKind.Date)),
+                new KeyValuePair<Type, IEdmPrimitiveType>(typeof(TimeOnly), GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay)),
+                new KeyValuePair<Type, IEdmPrimitiveType>(typeof(TimeOnly?), GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay)),
+#endif
             }
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 

--- a/Community.Data.OData.Linq/OData/Query/Expressions/ClrCanonicalFunctions.cs
+++ b/Community.Data.OData.Linq/OData/Query/Expressions/ClrCanonicalFunctions.cs
@@ -121,6 +121,25 @@ namespace Community.OData.Linq.OData.Query.Expressions
             new KeyValuePair<string, PropertyInfo>(MillisecondFunctionName, typeof(TimeSpan).GetProperty("Milliseconds")),
         }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
+#if NET6_0_OR_GREATER
+        // DateOnly properties
+        public static readonly Dictionary<string, PropertyInfo> DateOnlyProperties = new[]
+        {
+            new KeyValuePair<string, PropertyInfo>(YearFunctionName, typeof(DateOnly).GetProperty("Year")),
+            new KeyValuePair<string, PropertyInfo>(MonthFunctionName, typeof(DateOnly).GetProperty("Month")),
+            new KeyValuePair<string, PropertyInfo>(DayFunctionName, typeof(DateOnly).GetProperty("Day")),
+        }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+        // TimeOnly properties
+        public static readonly Dictionary<string, PropertyInfo> TimeOnlyProperties = new[]
+        {
+            new KeyValuePair<string, PropertyInfo>(HourFunctionName, typeof(TimeOnly).GetProperty("Hour")),
+            new KeyValuePair<string, PropertyInfo>(MinuteFunctionName, typeof(TimeOnly).GetProperty("Minute")),
+            new KeyValuePair<string, PropertyInfo>(SecondFunctionName, typeof(TimeOnly).GetProperty("Second")),
+            new KeyValuePair<string, PropertyInfo>(MillisecondFunctionName, typeof(TimeOnly).GetProperty("Millisecond")),
+        }.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+#endif
+
         // String Properties
         public static readonly PropertyInfo Length = typeof(string).GetProperty("Length");
 

--- a/Community.Data.OData.Linq/OData/Query/Expressions/ExpressionBinderBase.cs
+++ b/Community.Data.OData.Linq/OData/Query/Expressions/ExpressionBinderBase.cs
@@ -129,10 +129,11 @@ namespace Community.OData.Linq.OData.Query.Expressions
 
 #else
             if ((IsDateOrOffset(leftUnderlyingType) && IsDate(rightUnderlyingType)) ||
+                (IsDateOrOffset(leftUnderlyingType) && IsDateOnly(rightUnderlyingType)) ||
                 (IsDate(leftUnderlyingType) && IsDateOrOffset(rightUnderlyingType)) ||
-                (IsDateOnly(leftUnderlyingType) && IsDate(rightUnderlyingType)) ||
-                (IsDate(leftUnderlyingType) && IsDateOnly(rightUnderlyingType))
-                )
+                (IsDate(leftUnderlyingType) && IsDateOnly(rightUnderlyingType)) ||
+                (IsDateOnly(leftUnderlyingType) && IsDateOrOffset(rightUnderlyingType)) ||
+                (IsDateOnly(leftUnderlyingType) && IsDate(rightUnderlyingType)))
 #endif
             {
                 left = this.CreateDateBinaryExpression(left);
@@ -141,20 +142,25 @@ namespace Community.OData.Linq.OData.Query.Expressions
 
 #if !NET6_0_OR_GREATER
             if ((IsDateOrOffset(leftUnderlyingType) && IsTimeOfDay(rightUnderlyingType)) ||
+                (IsDateOrOffset(leftUnderlyingType) && IsTimeSpan(rightUnderlyingType)) ||
                 (IsTimeOfDay(leftUnderlyingType) && IsDateOrOffset(rightUnderlyingType)) ||
-                (IsTimeSpan(leftUnderlyingType) && IsTimeOfDay(rightUnderlyingType)) ||
-                (IsTimeOfDay(leftUnderlyingType) && IsTimeSpan(rightUnderlyingType)))
+                (IsTimeOfDay(leftUnderlyingType) && IsTimeSpan(rightUnderlyingType)) ||
+                (IsTimeSpan(leftUnderlyingType) && IsDateOrOffset(rightUnderlyingType)) ||
+                (IsTimeSpan(leftUnderlyingType) && IsTimeOfDay(rightUnderlyingType)))
 
 #else
             if ((IsDateOrOffset(leftUnderlyingType) && IsTimeOfDay(rightUnderlyingType)) ||
+                (IsDateOrOffset(leftUnderlyingType) && IsTimeSpan(rightUnderlyingType)) ||
+                (IsDateOrOffset(leftUnderlyingType) && IsTimeOnly(rightUnderlyingType)) ||
                 (IsTimeOfDay(leftUnderlyingType) && IsDateOrOffset(rightUnderlyingType)) ||
-                (IsTimeSpan(leftUnderlyingType) && IsTimeOfDay(rightUnderlyingType)) ||
                 (IsTimeOfDay(leftUnderlyingType) && IsTimeSpan(rightUnderlyingType)) ||
-                (IsTimeOnly(leftUnderlyingType) && IsTimeOfDay(rightUnderlyingType)) ||
                 (IsTimeOfDay(leftUnderlyingType) && IsTimeOnly(rightUnderlyingType)) ||
+                (IsTimeSpan(leftUnderlyingType) && IsDateOrOffset(rightUnderlyingType)) ||
+                (IsTimeSpan(leftUnderlyingType) && IsTimeOfDay(rightUnderlyingType)) ||
                 (IsTimeSpan(leftUnderlyingType) && IsTimeOnly(rightUnderlyingType)) ||
-                (IsTimeOnly(leftUnderlyingType) && IsTimeSpan(rightUnderlyingType))
-                )
+                (IsTimeOnly(leftUnderlyingType) && IsDateOrOffset(rightUnderlyingType)) ||
+                (IsTimeOnly(leftUnderlyingType) && IsTimeOfDay(rightUnderlyingType)) ||
+                (IsTimeOnly(leftUnderlyingType) && IsTimeSpan(rightUnderlyingType)))
 #endif
             {
                 left = this.CreateTimeBinaryExpression(left);

--- a/Community.Data.OData.Linq/OData/Query/Expressions/FilterBinder.cs
+++ b/Community.Data.OData.Linq/OData/Query/Expressions/FilterBinder.cs
@@ -1078,6 +1078,12 @@ namespace Community.OData.Linq.OData.Query.Expressions
             {
                 property = ClrCanonicalFunctions.DateTimeProperties[ClrCanonicalFunctions.MillisecondFunctionName];
             }
+#if NET6_0_OR_GREATER
+            else if (IsTimeOnly(parameter.Type))
+            {
+                property = ClrCanonicalFunctions.TimeOnlyProperties[ClrCanonicalFunctions.MillisecondFunctionName];
+            }
+#endif
             else if (IsTimeSpan(parameter.Type))
             {
                 property = ClrCanonicalFunctions.TimeSpanProperties[ClrCanonicalFunctions.MillisecondFunctionName];
@@ -1114,6 +1120,13 @@ namespace Community.OData.Linq.OData.Query.Expressions
                 Contract.Assert(ClrCanonicalFunctions.DateTimeProperties.ContainsKey(node.Name));
                 property = ClrCanonicalFunctions.DateTimeProperties[node.Name];
             }
+#if NET6_0_OR_GREATER
+            else if (IsDateOnly(parameter.Type))
+            {
+                Contract.Assert(ClrCanonicalFunctions.DateOnlyProperties.ContainsKey(node.Name));
+                property = ClrCanonicalFunctions.DateOnlyProperties[node.Name];
+            }
+#endif
             else
             {
                 Contract.Assert(ClrCanonicalFunctions.DateTimeOffsetProperties.ContainsKey(node.Name));


### PR DESCRIPTION
Hi,

I recently migrated a project to .NET6 and started to use DateOnly type introduced with it.
This caused an exception when used with this library because these new types (DateOnly and TimeOnly) are unknown.
So I tried to add support for them to the library, I tried to reproduce the same logic as the others types but I'm not sure if all the changes are correct, particularly the CreateBinaryExpression part. 

These changes fix the exception and works fines in my project but I only use simple case.

Do these changes look good to you ?